### PR TITLE
fix: mnemonicToEntropy checksum check

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -74,7 +74,7 @@ export function mnemonicToEntropy(
   const entropyBuffer = new Buffer(entropyBytes);
   const newChecksum = checksumBits(entropyBuffer);
 
-  if (newChecksum === checksum) throw "Invalid mnemonic checksum";
+  if (newChecksum !== checksum) throw "Invalid mnemonic checksum";
 
   return entropyBuffer.toString("hex");
 }


### PR DESCRIPTION
Hey @dreson4 , thanks for the repo. I fixed a couple of things at https://github.com/pwltr/react-native-quick-bip39 and rebased everything to the original JS implementation. I don't want to submit PRs for every change but here's a fix for a small bug. Feel free to merge any other changes. 